### PR TITLE
Fix Z axis offset after setting origin.

### DIFF
--- a/src/ArduinoAVR/Repetier/RF1000.cpp
+++ b/src/ArduinoAVR/Repetier/RF1000.cpp
@@ -7039,6 +7039,7 @@ void setZOrigin( void )
 	//Printer::zLength -= Printer::currentPosition[Z_AXIS];
 
     Printer::currentPositionSteps[Z_AXIS] = 0;
+    Printer::coordinateOffset[Z_AXIS] = 0;
     Printer::updateDerivedParameter();
 #if NONLINEAR_SYSTEM
     transformCartesianStepsToDeltaSteps(Printer::currentPositionSteps, Printer::currentDeltaPositionSteps);


### PR DESCRIPTION
In case a G92 or similar command was issued before a "Find Z origin"
or "Set Z origin" operation, the new Z origin may not be correct in
absolute coordinate mode.  The absolute coordinates would still
respect the Printer::coordinateOffset[Z_AXIS] value and therefore move
to a different height when sent a sequence like G90 - G0 Z0.

Reset the Z coordinate offset in the setZOrigin() function so that the
new height is correctly assumed as absolute Z0, as the user would
expect.
